### PR TITLE
Fix builder paths to allow root npm build

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -14,9 +14,9 @@ var
 
 // START
 var
-	rootPath = '../app/',
-	buildPath = path.join(rootPath, 'build'),
-	inputFilePath = path.join(rootPath, 'index.html'),
+rootPath = path.join(__dirname, '..', 'app'),
+buildPath = path.join(rootPath, 'build'),
+inputFilePath = path.join(rootPath, 'index.html'),
 	html = fs.readFileSync(inputFilePath, 'utf8'),
 
 	linkRegExp = /<link(.)+href="([^"]+)"(.)+\/>/gi,
@@ -205,7 +205,7 @@ minifiedCss = uglifycss.processString(combinedCss);
 
 
 // inlined
-combinedCss = inliner.inlineImages(combinedCss, '../app/css/');
+combinedCss = inliner.inlineImages(combinedCss, path.join(rootPath, 'css'));
 minifiedCss = uglifycss.processString(combinedCss);
 
 // write out


### PR DESCRIPTION
## Summary
- compute the application directory from the script location so the builder works when run via npm from the repository root
- reuse the resolved app path when inlining CSS assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cafc74de5c832494b845c21fb307b2