### PR TITLE
Add inline sofia.config overrides to index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -174,8 +174,40 @@
 	<link rel="stylesheet" href="js/menu/config-url.css" />
 
 	<!-- <script src="js/core/config-dbs.js" data-build="copy"></script> -->
-	<script src="js/core/config-custom.js" data-build="copy"></script>
-	<link rel="stylesheet" href="css/custom.css" data-build="copy" />
+        <script src="js/core/config-custom.js" data-build="copy"></script>
+        <script>
+            sofia.config = $.extend(sofia.config, {
+                siteTitle: '',
+                settingsPrefix: '20170923',
+
+                baseContentUrl: 'https://inscript.bible.cloud/',
+                serverSearchPath: 'https://arc.dbs.org/api/bible-search/',
+                // Icon Skins (icons.svg, icons-pastel.svg, icons-black.svg)
+                icons: 'build/icons.svg',
+
+
+                // First Load Set
+                windows: [
+                    { type: 'bible', data: { textid: 'ENGWEB', fragmentid: 'JN3_16' } },
+                    { type: 'bible', data: { textid: 'ENGKJV', fragmentid: 'JN3_16' } }],
+                newBibleWindowVersion: 'ENGWEB',
+                deafBibleWindowDefaultBibleVersion: 'ASESLS',
+                newCommentaryWindowTextId: "comm_eng_tske",
+
+                // Switches
+                enableBibleSelectorTabs: false,
+                enableFeedback: true,
+                eng2pEnableAll: true,
+                enableAmericanBibleSociety: false,
+                enableDeafBibleWindow: false,
+                deafCentric: false,
+
+                // Enables the use of online sources (Google Maps, FCBH, Jesus Film, etc.)
+                enableOnlineSources: false,
+
+            });
+        </script>
+        <link rel="stylesheet" href="css/custom.css" data-build="copy" />
 
 	<noscript><meta http-equiv="refresh" content="1; url=content/texts/"></noscript>
 	<!--[if lte IE 8]>


### PR DESCRIPTION
## Summary
- add inline script that extends `sofia.config` with custom URLs, window defaults, and feature toggles for the app entry point

## Testing
- not run (HTML-only change)


------
https://chatgpt.com/codex/tasks/task_e_68caff67a62083248ef5afd9f8ed1194