### PR TITLE
Modernize jQuery helpers for 3.7.1 compatibility

### DIFF
--- a/app/js/common/clickoff.js
+++ b/app/js/common/clickoff.js
@@ -1,7 +1,8 @@
 var ClickOff = {
 
 	clickoffid: '',
-	clickTargets:[],
+        clickTargets:[],
+        boundDocClick: null,
 
 	getClickTargets: function() {
 		return this.clickTargets;
@@ -84,18 +85,22 @@ var ClickOff = {
 		this.unbindDocClick();
 	},
 
-	bindDocClick: function() {
-		this.unbindDocClick();
+        bindDocClick: function() {
+                this.unbindDocClick();
 
-		var proxy = this.proxy = $.proxy( this, 'docClick' );
+                var that = this;
+                this.boundDocClick = function() {
+                        return that.docClick.apply(that, arguments);
+                };
 
-		$(document).on('click.' + this.clickoffid, proxy);
-	},
+                $(document).on('click.' + this.clickoffid, this.boundDocClick);
+        },
 
-	unbindDocClick: function() {
-		if (this.proxy) {
-			$(document).off('click.' + this.clickoffid, this.proxy);
-		}
-	}
+        unbindDocClick: function() {
+                if (this.boundDocClick) {
+                        $(document).off('click.' + this.clickoffid, this.boundDocClick);
+                        this.boundDocClick = null;
+                }
+        }
 
 };

--- a/app/js/texts/search.js
+++ b/app/js/texts/search.js
@@ -383,10 +383,34 @@ SearchTools = {
 
 	isLemmaRegExp: /[GgHh]\d{1,6}/g,
 
-	createSearchTerms: function (searchText, isLemmaSearch) {
-		var searchTermsRegExp = [];
+        uniqueStrings: function (items) {
+                if (!items || typeof items.length === 'undefined') {
+                        return [];
+                }
 
-		if (isLemmaSearch) {
+                if (typeof Set === 'function' && typeof Array.from === 'function') {
+                        return Array.from(new Set(items));
+                }
+
+                var seen = Object.create(null);
+                var uniqueItems = [];
+
+                for (var i = 0, il = items.length; i < il; i++) {
+                        var item = items[i];
+
+                        if (!seen[item]) {
+                                seen[item] = true;
+                                uniqueItems.push(item);
+                        }
+                }
+
+                return uniqueItems;
+        },
+
+        createSearchTerms: function (searchText, isLemmaSearch) {
+                var searchTermsRegExp = [];
+
+                if (isLemmaSearch) {
 
 			var strongNumbers = searchText.split(' ');
 
@@ -412,21 +436,21 @@ SearchTools = {
 
 			} else {
 
-				// ASCII characters have predictable word boundaries (space ' ' = \b)
-				SearchTools.isAsciiRegExp.lastIndex = 0;
+                                // ASCII characters have predictable word boundaries (space ' ' = \b)
+                                SearchTools.isAsciiRegExp.lastIndex = 0;
 
-				if (SearchTools.isAsciiRegExp.test( searchText )) {
+                                if (SearchTools.isAsciiRegExp.test( searchText )) {
 
-					// for non-quoted searches, use "AND" search
-					var andSearchParts = searchText.split(/\s+AND\s+|\s+/gi);
+                                        // for non-quoted searches, use "AND" search
+                                        var andSearchParts = searchText.split(/\s+AND\s+|\s+/gi);
 
-					// filter for duplicate words
-					andSearchParts = $.unique(andSearchParts);
+                                        // filter for duplicate words
+                                        andSearchParts = SearchTools.uniqueStrings(andSearchParts);
 
-					for (var i=0, il=andSearchParts.length; i<il; i++) {
+                                        for (var i=0, il=andSearchParts.length; i<il; i++) {
 
-						var part = andSearchParts[i],
-							partRegex = new XRegExp('\\b(' + part + ')\\b', 'gi');
+                                                var part = andSearchParts[i],
+                                                        partRegex = new XRegExp('\\b(' + part + ')\\b', 'gi');
 
 						searchTermsRegExp.push( partRegex );
 					}
@@ -509,10 +533,10 @@ SearchTools = {
 
 		addWord();
 
-		words = $.unique(words);
+                words = SearchTools.uniqueStrings(words);
 
-		return words;
-	},
+                return words;
+        },
 
 	HASHSIZE: 20,
 
@@ -781,16 +805,18 @@ SearchIndexLoader = function() {
 						if (searchDivisions.length == 0 || searchDivisions.indexOf(dbsBookCode) > -1) {
 
 							// see if we already created data for this section id
-							var sectionidInfo = $.grep(loadedResults, function(val){ return val.sectionid == sectionid; });
+                                                        var sectionidInfo = loadedResults.find(function(val) {
+                                                                return val.sectionid == sectionid;
+                                                        });
 
-							// create new data
-							if (sectionidInfo.length == 0) {
-								loadedResults.push({sectionid: sectionid, fragmentids: [fragmentid]});
-							}
-							// add to this sectionid
-							else {
-								sectionidInfo[0].fragmentids.push(fragmentid);
-							}
+                                                        // create new data
+                                                        if (!sectionidInfo) {
+                                                                loadedResults.push({sectionid: sectionid, fragmentids: [fragmentid]});
+                                                        }
+                                                        // add to this sectionid
+                                                        else {
+                                                                sectionidInfo.fragmentids.push(fragmentid);
+                                                        }
 						}
 					}
 				}

--- a/app/js/windows/mapswindow.js
+++ b/app/js/windows/mapswindow.js
@@ -256,12 +256,12 @@ var MapWindow = function(id, parent, data) {
 	}
 
 	function openLocation(location) {
-		var verses_html = $.map(location.verses, function(a) {
-			var bible_ref = new bible.Reference(a),
-				sectionid = bible_ref.bookid + bible_ref.chapter,
-				fragmentid = sectionid + '_' + bible_ref.verse1;
+                var verses_html = (location.verses || []).map(function(a) {
+                        var bible_ref = new bible.Reference(a),
+                                sectionid = bible_ref.bookid + bible_ref.chapter,
+                                fragmentid = sectionid + '_' + bible_ref.verse1;
 
-			return '<span class="verse" style="text-decoration:underline; cursor: pointer" data-sectionid="' + sectionid + '" data-fragmentid="' + fragmentid + '">' + bible_ref.toString() + '</span>';
+                        return '<span class="verse" style="text-decoration:underline; cursor: pointer" data-sectionid="' + sectionid + '" data-fragmentid="' + fragmentid + '">' + bible_ref.toString() + '</span>';
 		});
 
 		infowindow.setContent(


### PR DESCRIPTION
## Summary
- update `SearchTools.uniqueStrings` to use native Set support when available and replace `$.grep` usage with `Array.prototype.find`
- replace jQuery array helpers in Maps window with native `Array.prototype.map`
- remove reliance on `$.proxy` in the click-off utility by binding handlers directly

## Testing
- npm run build --silent

------
https://chatgpt.com/codex/tasks/task_e_68cb075e430883249c577118ad5cfdea