### PR TITLE
Specify encoding when creating SVG buffer

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -174,7 +174,7 @@ var inliner = {
 					//content = content.replace(/\>[\n\t\s]+\</g,'');
 					content = content.replace(/\t+/g,' ');
 
-					base64 = new Buffer(content).toString('base64');
+                                        base64 = Buffer.from(content, 'utf8').toString('base64');
 				} else {
 					base64 = fs.readFileSync(filePath).toString('base64');
 				}


### PR DESCRIPTION
## Summary
- explicitly specify the UTF-8 encoding when converting SVG content into a buffer before base64 encoding

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb29fb8eec8324901359ad73e85b6a