### PR TITLE
Replace deprecated Buffer constructor

### DIFF
--- a/tools/builder.js
+++ b/tools/builder.js
@@ -174,7 +174,7 @@ var inliner = {
 					//content = content.replace(/\>[\n\t\s]+\</g,'');
 					content = content.replace(/\t+/g,' ');
 
-					base64 = new Buffer(content).toString('base64');
+                                        base64 = Buffer.from(content, 'utf8').toString('base64');
 				} else {
 					base64 = fs.readFileSync(filePath).toString('base64');
 				}


### PR DESCRIPTION
## Summary
- use `Buffer.from` when base64-encoding SVG assets in the build script to avoid Node.js deprecation warnings

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb2b2ae5988324a6190080da39f494