### PR TITLE
Add automated check for index-build.html resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ tools/_old/
 content/texts/*.*
 build/
 config-custom.js
+!app/js/core/config-custom.js
 app/content/texts/
 !app/content/texts/README.md
 **/node_modules/

--- a/app/js/core/config-custom.js
+++ b/app/js/core/config-custom.js
@@ -1,0 +1,20 @@
+/*
+ * Project-specific configuration overrides.
+ *
+ * This default file keeps the build output self-contained by ensuring a
+ * config file is always copied into the build/ directory.  Customize these
+ * values as needed for deployment environments.
+ */
+/* global sofia, $ */
+
+if (typeof sofia === 'undefined') {
+  throw new Error('The global "sofia" namespace must be loaded before config-custom.js.');
+}
+
+// Extend the default configuration with any overrides for the build.
+sofia.config = $.extend(true, sofia.config, {});
+
+// Ensure an object exists for optional custom configurations.
+if (typeof sofia.customConfigs === 'undefined') {
+  sofia.customConfigs = {};
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "build:index": "node tools/create_texts_index.js",
     "build:deafbibles": "node tools/generatedeafbibles.js",
     "build:content": "npm run build:texts && npm run build:deafbibles && npm run build:index",
-    "build": "node tools/builder.js"
+    "build": "node tools/builder.js",
+    "test:index": "node tools/test_index_html.js",
+    "test": "npm run build && npm run test:index"
   },
   "dependencies": {
     "base32": "0.0.6",

--- a/tools/test_index_html.js
+++ b/tools/test_index_html.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+const jsdom = require('jsdom');
+
+const appDir = path.join(__dirname, '..', 'app');
+const indexBuildPath = path.join(appDir, 'index-build.html');
+const buildDir = path.join(appDir, 'build');
+
+if (!fs.existsSync(buildDir)) {
+  console.error('The build directory was not found. Run "npm run build" first.');
+  process.exit(1);
+}
+
+if (!fs.existsSync(indexBuildPath)) {
+  console.error('The index-build.html file was not found under app/.');
+  process.exit(1);
+}
+
+const indexHtml = fs.readFileSync(indexBuildPath, 'utf8');
+const dom = jsdom.jsdom(indexHtml);
+const document = dom.defaultView && dom.defaultView.document ? dom.defaultView.document : dom;
+
+const selectors = ['link[href]', 'script[src]'];
+const resourceNodes = selectors
+  .map((selector) => Array.from(document.querySelectorAll(selector)))
+  .reduce((all, nodes) => all.concat(nodes), []);
+
+const missingResources = [];
+
+resourceNodes.forEach((node) => {
+  const attribute = node.tagName === 'LINK' ? 'href' : 'src';
+  const value = node.getAttribute(attribute);
+
+  if (!value) {
+    return;
+  }
+
+  // Skip external resources referenced by URL.
+  if (/^(?:https?:)?\/\//i.test(value)) {
+    return;
+  }
+
+  const resourcePath = path.join(appDir, value);
+  if (!fs.existsSync(resourcePath)) {
+    missingResources.push(value);
+  }
+});
+
+if (missingResources.length > 0) {
+  console.error('index-build.html references missing resources:');
+  missingResources.forEach((resource) => console.error(` - ${resource}`));
+  process.exit(1);
+}
+
+const startup = document.querySelector('#startup');
+if (!startup) {
+  console.error('The #startup element is missing from index-build.html.');
+  process.exit(1);
+}
+
+console.log('index-build.html passed resource validation.');


### PR DESCRIPTION
## Summary
- add a default config-custom.js stub so the build output always includes a configuration file
- add a script that validates index-build.html references after running the build and wire it to npm test
- update .gitignore so the tracked stub config is not ignored

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb352c0d248324b99c07646da6acbf