### PR TITLE
Remove rimraf dependency to eliminate inflight

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "natural": "^0.2.1",
     "progress": "^1.1.8",
     "readline": "^1.3.0",
-    "rimraf": "^2.5.2",
     "stream": "0.0.2",
     "uglify-js": "^2.6.2",
     "uglifycss": "0.0.20",

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -9,14 +9,13 @@
 
 // MODULES
 var fs = require('fs'),
-	path = require('path'),
-	rmrf = require('rimraf').sync,
-	mkdirp = require('mkdirp').sync,
-	bibleData = require('./data/bible_data.js'),
-	bibleFormatter = require('./bible_formatter.js'),
-	verseIndexer = require('./verse_indexer.js'),
-	ProgressBar = require('progress'),
-	argv = require('minimist')(process.argv.slice(2));
+        path = require('path'),
+        mkdirp = require('mkdirp').sync,
+        bibleData = require('./data/bible_data.js'),
+        bibleFormatter = require('./bible_formatter.js'),
+        verseIndexer = require('./verse_indexer.js'),
+        ProgressBar = require('progress'),
+        argv = require('minimist')(process.argv.slice(2));
 
 
 // VARS
@@ -71,9 +70,29 @@ function updateProgress() {
 	progressBar.tick();
 }
 
+function removeDirectoryContents(folderPath) {
+        if (!fs.existsSync(folderPath)) {
+                return;
+        }
+
+        var entries = fs.readdirSync(folderPath);
+
+        entries.forEach(function(entry) {
+                var entryPath = path.join(folderPath, entry);
+                var entryStats = fs.lstatSync(entryPath);
+
+                if (entryStats.isDirectory()) {
+                        removeDirectoryContents(entryPath);
+                        fs.rmdirSync(entryPath);
+                } else {
+                        fs.unlinkSync(entryPath);
+                }
+        });
+}
+
 function cleanFolder(folderPath) {
-	mkdirp(folderPath);
-	rmrf(path.join(folderPath, '*'));
+        mkdirp(folderPath);
+        removeDirectoryContents(folderPath);
 }
 
 function convertFolder(inputPath) {


### PR DESCRIPTION
## Summary
- replace the rimraf-based folder cleanup in `tools/generate.js` with an internal recursive remover built on `fs`
- drop the `rimraf` dependency from `package.json`, removing the unsupported `inflight` transitive dependency

## Testing
- node tools/generate.js -h

------
https://chatgpt.com/codex/tasks/task_e_68cb6bf4bcfc8324b83182887439cde8